### PR TITLE
[dashboard/contact] Display notice and no redirect instead redirect to localhost:3000

### DIFF
--- a/app/[locale]/dashboard/contact/__components__/contact-form.tsx
+++ b/app/[locale]/dashboard/contact/__components__/contact-form.tsx
@@ -58,9 +58,9 @@ export default function ContactForm() {
           </div>
         </div>
         <div className="mt-8 flex justify-end">
-          <a onClick={handleSubmit} className="flex-none rounded-md bg-primary dark:bg-primary px-3.5 py-2.5 text-sm font-semibold text-gray-50 dark:text-gray-900 shadow-sm hover:bg-gray-900 dark:hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary" >
+          <button onClick={handleSubmit} className="flex-none rounded-md bg-primary dark:bg-primary px-3.5 py-2.5 text-sm font-semibold text-gray-50 dark:text-gray-900 shadow-sm hover:bg-gray-900 dark:hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary" >
             Send message
-          </a>
+          </button>
         </div>
       </div>
     </form>

--- a/app/api/user_contact/route.ts
+++ b/app/api/user_contact/route.ts
@@ -74,10 +74,9 @@ export async function POST(request: NextRequest) {
       `
     });
 
-
     if (data) {
       return NextResponse.json({
-        message: 'User has been sended contact!',
+        message: 'Your message has been sent successfully!',
         status: 200
       });
     }


### PR DESCRIPTION
Work List:
- [x] Display notice and no redirect instead redirect to localhost:3000

| when | http code | show |
|------|-----------|-------|
| When NOT login | unauthenticated (401) |  <img width="1280" alt="401" src="https://github.com/TakeNoteAI/takenote/assets/10452690/583c4e04-c1f8-4691-9fae-0309ce49bfb4"> |
| don't fill Message and call API | Missing require fields (400) | <img width="1277" alt="400" src="https://github.com/TakeNoteAI/takenote/assets/10452690/93e3d7ac-a3c2-4d0c-bfa0-7f6efaec6bb1"> |
| Call API with email is NOT logined account | unauthorization (403) | <img width="1273" alt="403" src="https://github.com/TakeNoteAI/takenote/assets/10452690/35cd8b00-e160-4481-8cfd-686259ca1ad8"> |
| When send contact successfully | success (200) | <img width="1275" alt="200" src="https://github.com/TakeNoteAI/takenote/assets/10452690/ab7ed9bb-d4a5-494b-bafe-b568c5932176"> |
| Occurred exception | Exception (500) | |