### PR TITLE
Sentiment/fix comment and update

### DIFF
--- a/app/[locale]/dashboard/files/[id]/__components__/TabSentiment.tsx
+++ b/app/[locale]/dashboard/files/[id]/__components__/TabSentiment.tsx
@@ -19,6 +19,11 @@ const colors: tColors = {
   Negative: '#DF665A'
 };
 
+const TimeFormatAt = (seconds: number) => {
+  const str = new Date(seconds * 1000).toISOString();
+  return seconds >= 3600 ? str.slice(11, 19) : str.slice(14, 19);
+};
+
 export default function TabSentiment({
   sentimentData,
   speakerDiarization
@@ -32,7 +37,7 @@ export default function TabSentiment({
 
   // console.log('speakerDiarization', speakerDiarization);
   const hours = speakerDiarization?.length
-    ? speakerDiarization?.map((item) => item.end)
+    ? speakerDiarization?.map((item) => TimeFormatAt(item.end))
     : [];
   // console.log("hours", hours);
 


### PR DESCRIPTION
Task: https://trello.com/c/Pl8Y16HU/8-8-fe-high-fix-the-sentiment-graphic#comment-64f8a4368464db0aad0215ed
Work

Work List:
- [x]  fixed 2 for value of Neatral|Positive|Negative
- [x] there should be an ‘Overall Sentiment’ score displayed at the top of the page
- [x] the time stamp should be displayed as ‘x minutes, y seconds’ (rather than just an integer. 